### PR TITLE
Adds section for common MPI error

### DIFF
--- a/07-Interoperability.markdown
+++ b/07-Interoperability.markdown
@@ -70,7 +70,12 @@ as device pointers using the `host_data` region.
 The call to `cublasSaxpy` can be changed to any function that expects device
 pointers as parameters.
 
-### Device-Aware MPI
+### Asynchronous Device Libraries
+***NOTE:*** When using the `host_data` region to pass data into asynchronous
+libraries calls or kernels care must be taken regarding the lifetime of data
+on the device. A common example of this pattern is passing device data to a
+device-aware MPI library, as illustrated below.  
+
 A common use of the `host_data` region is to pass device pointers into a
 device-aware MPI implementation. Such MPI libraries may have specific
 optimizations when passed device data, such as Remote Direct Memory Access
@@ -139,10 +144,6 @@ use `host_data` with asynchronous MPI calls.
     !$acc end data
     ! Data in `buf` potentially removed from device
 ~~~~
-
-**Note:** This same issue can occur with other asynchronous device libaries or device kernels. 
-When using `host_data` with any asynchronous routine care must be taken to ensure the affected
-buffers can be safely re-used or deallocated. 
 
 Using Device Pointers
 ---------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM pandoc/latex:latest
 #RUN apk --no-cache add texlive-xetex texmf-dist-pictures texmf-dist-latexextra poppler-utils && texhash
-ADD http://mirror.ctan.org/systems/texlive/tlnet/update-tlmgr-latest.sh /tmp
-RUN sh /tmp/update-tlmgr-latest.sh -- --upgrade
-RUN tlmgr update --self --all 
-RUN tlmgr install ifoddpage tikzpagenodes blindtext textpos && luaotfload-tool -fu
+#ADD http://mirror.ctan.org/systems/texlive/tlnet/update-tlmgr-latest.sh /tmp
+#RUN sh /tmp/update-tlmgr-latest.sh -- --upgrade
+#RUN tlmgr update --self --all 
+RUN tlmgr update --all 
+RUN tlmgr install ifoddpage tikzpagenodes blindtext textpos koma-script pdfpages && luaotfload-tool -fu

--- a/cover-page/main.tex
+++ b/cover-page/main.tex
@@ -52,7 +52,7 @@
 \end{textblock*}
 
 \begin{textblock*}{10.7cm}(1.8cm,26.3cm)
-\textcolor{myblue}{ \tiny © 2020 openacc-standard.org. All Rights Reserved.}
+\textcolor{myblue}{ \tiny © 2022 openacc-standard.org. All Rights Reserved.}
 %\textcolor{myblue}{\fontspec{QTHelvetCnd} \tiny © 2020 openacc-standard.org. All Rights Reserved.}
 \end{textblock*}
 


### PR DESCRIPTION
This adds a section about using `host_data` with asynchronous MPI. It was suggested by an OpenACC user who encountered this error. 