### PR TITLE
Typos and other suggestions

### DIFF
--- a/02-Porting.markdown
+++ b/02-Porting.markdown
@@ -117,7 +117,7 @@ a long time and compute a significant amount work each. Modern GPUs and many-cor
 processors, however, are designed to execute fine-grained threads, which are
 short-lived and execute a minimal amount of work each. These parallel
 architectures achieve high throughput by trading single-threaded performance in
-favor of several orders in magnitude more parallelism. This means that when
+favor of more parallelism. This means that when
 accelerating an application with OpenACC, which was designed in light of 
 increased hardware parallelism, it may be necessary to refactor the code to
 favor tightly-nested loops with a significant amount of data reuse. In many

--- a/03-Analyze.markdown
+++ b/03-Analyze.markdown
@@ -7,7 +7,7 @@ performance analysis tool is outside of the scope of this document. The purpose
 of this section is to provide guidance on choosing important sections of code
 for acceleration, which is independent of the profiling tools available. 
 
-Throughout this guide, the NVIDIA Nsight Systems performance analysis tool which is provided with the CUDA toolkit, will be used for CPU profiling. When accelerator profiling is needed, the application will be run on an NVIDIA GPU and the NVIDIA Nsight Systems profiler will be again be used.
+Throughout this guide, the NVIDIA Nsight Systems performance analysis tool which is provided with the CUDA toolkit, will be used for CPU profiling. When accelerator profiling is needed, the application will be run on an NVIDIA GPU and the NVIDIA Nsight Systems profiler will be used again.
 
 Baseline Profiling
 ------------------

--- a/04-Parallelize.markdown
+++ b/04-Parallelize.markdown
@@ -326,7 +326,7 @@ necessary part of parallelization to ensure correctness.
 The `atomic` directive accepts one of four clauses to declare the type of
 operation contained within the region. The `read` operation ensures that no two
 loop iterations will read from the region at the same time. The `write`
-operation will ensure that no two iterations with write to the region at the
+operation will ensure that no two iterations will write to the region at the
 same time. An `update` operation is a combined read and write. Finally a
 `capture` operation performs an update, but saves the value calculated in that
 region to use in the code that follows. If no clause is given, then an update
@@ -474,9 +474,9 @@ loop` directive on the `j` loops and detect for themselves that the `i` loop
 can also be parallelized without needing the `loop` directives on the `i`
 loops. By placing a `loop` directive on each loop that can be
 parallelized, the programmer ensures that the compiler will understand that the
-loop is safe the parallelize. When used within a `parallel` region, the `loop`
+loop is safe to parallelize. When used within a `parallel` region, the `loop`
 directive asserts that the loop iterations are independent of each other and
-are safe the parallelize and should be used to provide the compiler as much
+are safe to parallelize and should be used to provide the compiler as much
 information about the loops as possible.
 
 Building the above code using the NVHPC compiler produces the
@@ -625,8 +625,8 @@ discussed in a later chapter.
 
 At this point we have expressed all of the parallelism in the example code and
 the compiler has parallelized it for an accelerator device. Analyzing the
-performance of this code may yield surprising results on some accelerators,
-however. The results below demonstrate the performance of this code on 1 - 16
+performance of this code may yield surprising results on some accelerators.
+The results below demonstrate the performance of this code on 1 - 16
 CPU threads on an AMD Threadripper CPU and an NVIDIA Volta V100
 GPU using both implementations above. The *y axis* for figure 3.1 is execution
 time in seconds, so smaller is better. For the two OpenACC versions, the bar is
@@ -639,7 +639,7 @@ The performance of this improves as more CPU threads are added to the calculatio
 however, since the code is memory-bound the performance benefit of adding
 additional threads quickly diminishes. Also, the OpenACC versions perform poorly
 compared to the CPU
-baseline. The both the OpenACC `kernels` and `parallel loop` versions perform
+baseline. Both the OpenACC `kernels` and `parallel loop` versions perform
 worse than the serial CPU baseline. It is also clear that the `parallel loop` version
 spends significantly more time in data transfer than the `kernels` version.
 Further performance analysis is necessary to
@@ -673,7 +673,7 @@ When an OpenACC compiler parallelizes a region of code it must analyze the data
 that is needed within that region and copy it to and from the accelerator if
 necessary. This analysis is done at a per-region level and will typically
 default to copying arrays used on the accelerator both to and from the device
-at the beginning and end of the region respectively. Since the `parallel loop`
+at the beginning and end of the region, respectively. Since the `parallel loop`
 version has two compute regions, as opposed to only one in the `kernels`
 version, data is copied back and forth between the two regions. As a result,
 the copy and overhead times are roughly twice that of the `kernels` region,

--- a/05-Data-Locality.markdown
+++ b/05-Data-Locality.markdown
@@ -308,7 +308,7 @@ copy constructor will be responsible for allocating space on the device for the
 class that it is creating, but it will also rely on data that is managed by the
 class being copied. Since OpenACC does not currently provide a
 portable way to copy from one array to another, like a `memcpy` on the host, a
-loop is used to copy each individual element to from one array to the other.
+loop is used to copy each individual element from one array to the other.
 Because we know that the `Data` object passed in will also have its members on
 the device, we use a `present` clause on the `parallel loop` to inform the
 compiler that no data movement is necessary.

--- a/06-Loops.markdown
+++ b/06-Loops.markdown
@@ -124,7 +124,7 @@ one _worker_, which operates on a _vector_ of data.
 Mapping Parallelism to the Hardware
 -----------------------------------
 With some understanding of how the underlying accelerator hardware works it's
-possible to inform that compiler how it should map the loop iterations into
+possible to inform the compiler how it should map the loop iterations into
 parallelism on the hardware. It's worth restating that the more detail the
 compiler is given about how to map the parallelism onto a particular
 accelerator the less performance portable the code will be. For instance, 
@@ -219,7 +219,7 @@ form of the `num_gangs`, `num_workers`, and `vector_length` clauses to the
 ~~~~ {.fortran .numberLines}
     !$acc parallel loop gang vector_length(128)
     do j=1,M
-      !$acc loop vector(128)
+      !$acc loop vector
       do i=1,N
 ~~~~
 
@@ -412,7 +412,7 @@ application.
     matvec(const matrix &, const vector &, const vector &):
           3, Generating Tesla code
               4, #pragma acc loop gang /* blockIdx.x */
-              9, #pragma acc loop vector(128) /* threadIdx.x */
+              9, #pragma acc loop vector(256) /* threadIdx.x */
                  Generating reduction(+:sum)
           3, Generating present(ycoefs[:],xcoefs[:],row_offsets[:],Acoefs[:],cols[:])
           9, Loop is parallelizable

--- a/07-Interoperability.markdown
+++ b/07-Interoperability.markdown
@@ -5,7 +5,7 @@ OpenACC code with code accelerated using other parallel programming languages,
 such as CUDA or OpenCL, or accelerated math libraries. This interoperability
 means that a developer can choose the programming paradigm that makes the most
 sense in the particular situation and leverage code and libraries that may
-already be available. Developers don't need to decide at the begining of a
+already be available. Developers don't need to decide at the beginning of a
 project between OpenACC *or* something else, they can choose to use OpenACC *and*
 other technologies.
 
@@ -54,7 +54,7 @@ as device pointers using the `host_data` region.
 ---
 
 ~~~~ {.fortran .numberLines}
-    !$acc data create(x,y)
+    !$acc data create(x) copyout(y)
     !$acc kernels
     X(:) = 1.0
     Y(:) = 0.0
@@ -63,7 +63,6 @@ as device pointers using the `host_data` region.
     !$acc host_data use_device(x,y)
     call cublassaxpy(N, 2.0, x, 1, y, 1)
     !$acc end host_data
-    !$acc update self(y)
     !$acc end data
 ~~~~
 
@@ -153,7 +152,7 @@ region to an existing accelerated application. In this case the arrays may be
 managed outside of OpenACC and already exist on the device. For this case
 OpenACC provides the `deviceptr` data clause, which may be used where any data
 clause may appear. This clause informs the compiler that the variables
-specified are already device on the device and no other action needs to be
+specified are already on the device and no other action needs to be
 taken on them. The example below uses the `acc_malloc` function, which
 allocates device memory and returns a pointer, to allocate an array only on the
 device and then uses that array within an OpenACC region.
@@ -281,7 +280,7 @@ to memory regardless of whether it is accessed from the host or device, in CUDA
 6.0. In many ways managed memory is similar to OpenACC memory management, in
 that only a single reference to the memory is necessary and the runtime will
 handle the complexities of data movement. The advantage that managed memory
-sometimes has it that it is better able to handle complex data structures, such
+sometimes has is that it is better able to handle complex data structures, such
 as C++ classes or structures containing pointers, since pointer references are
 valid on both the host and the device. More information about CUDA Managed
 Memory can be obtained from NVIDIA. To use managed memory within an OpenACC

--- a/08-Advanced.markdown
+++ b/08-Advanced.markdown
@@ -442,7 +442,7 @@ that should be used and is functionally equivalent to the
 ---
 
 ### Multi-device Programming Example ###
-As a example of multi-device programming, it's possible to further extend the
+As an example of multi-device programming, it's possible to further extend the
 mandelbrot example used previously to send different blocks of work to
 different accelerators. In order to make this work, it's necessary to ensure
 that device copies of the data are created on each device. We will do this by
@@ -455,7 +455,7 @@ necessary to allocate just the pertinent parts of the data on each accelerator.
 
 Once the data has been created on each device, a call to `acc_set_device_num()`
 in the blocking loop, using a simple modulus operation to select which device
-should receive each block, will sent blocks to different devices. 
+should receive each block, will send blocks to different devices.
 
 Lastly it's necessary to introduce a loop over devices to wait on each device
 to complete. Since the `wait` directive is per-device, the loop will once again


### PR DESCRIPTION
Last week I started learning OpenACC, for this reason I read the programming guide available on your website. Since I saw it is fairly new (April 2022) and I was already reading it anyway, I took the opportunity to suggest some corrections to errors (mainly typos) that I found in the text.

For more details please refer to the annotated file in the attachment. Note that I used Adobe Acrobat Reader DC (version 2022.002.20212) for the annotations.

[openacc-guide-annotations.pdf](https://github.com/OpenACC/openacc-best-practices-guide/files/9695641/openacc-guide-annotations.pdf)
